### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,4 @@
-MIT License
-
-Copyright (c) 2021 HashiCorp
+Copyright (c) 2021 HashiCorp, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
A recent audit of public HashiCorp repos identified this `LICENSE` file as not adhering to our standard format. This commit brings the `LICENSE` file back into compliance with HashiCorp OSS best practices.