### PR TITLE
Fix lower method invocation in gw-service-account.py

### DIFF
--- a/gw-service-account.py
+++ b/gw-service-account.py
@@ -211,7 +211,7 @@ async def verify_service_account_authorization():
       print(f"\n{authorize_url}\n")
       answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
                      "cancel:")
-      if answer.lower == "c":
+      if answer.lower() == "c":
         scopes_are_authorized = True
       if answer.lower() == "n":
         sys.exit(0)


### PR DESCRIPTION
Was getting the unauthorized scopes error (line 191) due to a GCP organizational mix-up (I think the script was trying to use "No org" instead of my org, perhaps that could also be fixed, though shouldn't really happen in the real world) and I noticed "c">Enter wasn't doing anything. This fixes that.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204762449921439